### PR TITLE
15 api to share encrypted data with organization

### DIFF
--- a/organization/users_organizations.go
+++ b/organization/users_organizations.go
@@ -7,38 +7,6 @@ import (
 	"encore.dev/storage/sqldb"
 )
 
-type PostUserToOrganizationParams struct {
-	OrganizationPubKey string `json:"organization_pub_key"`
-	UserPubKey         string `json:"user_pub_key"`
-	UserInformation    string `json:"content"`
-}
-
-type UserPosted struct {
-	Successful bool `json:"success"`
-}
-
-//encore:api public method=POST
-func PostUserToOrganization(ctx context.Context, params *PostUserToOrganizationParams) (*UserPosted, error) {
-
-	registerID := commons.GenerateID()
-	organizationPubKey := params.OrganizationPubKey
-	userPubKey := params.UserPubKey
-	userInformation := params.UserInformation
-
-	// TODO:
-	// Use some proper ORM instead of raw SQL querie
-	_, err := sqldb.Exec(ctx, "INSERT INTO user_organization (id, organization_pub_key, user_pub_key, content) VALUES ($1, $2, $3, $4);",
-		registerID,
-		organizationPubKey,
-		userPubKey,
-		userInformation)
-	if err != nil {
-		return nil, err
-	}
-
-	return &UserPosted{Successful: true}, nil
-}
-
 type GetUsersFromOrganizationParams struct {
 	OrganizationId string `json:"organizationId"`
 }
@@ -77,4 +45,62 @@ func GetUsersFromOrganization(ctx context.Context, params *GetUsersFromOrganizat
 
 	response.Users = users
 	return &response, nil
+}
+
+type PostUserToOrganizationParams struct {
+	OrganizationPubKey string `json:"organization_pub_key"`
+	UserPubKey         string `json:"user_pub_key"`
+	UserInformation    string `json:"content"`
+}
+
+type UserPosted struct {
+	Successful string `json:"success"`
+}
+
+//encore:api public method=POST
+func PostUserToOrganization(ctx context.Context, params *PostUserToOrganizationParams) (*UserPosted, error) {
+
+	registerID := commons.GenerateID()
+	organizationPubKey := params.OrganizationPubKey
+	userPubKey := params.UserPubKey
+	userInformation := params.UserInformation
+
+	paramsGetUsersFromOrganizationParams := GetUsersFromOrganizationParams{OrganizationId: organizationPubKey}
+
+	previousData, err := GetUsersFromOrganization(ctx, &paramsGetUsersFromOrganizationParams)
+	if err != nil {
+		return nil, err
+	}
+
+	usersRegistered := previousData.Users
+	userPreviouslyRegistered := false
+
+	for _, user := range usersRegistered {
+		if user.UserId == userPubKey {
+			userPreviouslyRegistered = true
+		}
+	}
+
+	if userPreviouslyRegistered {
+		_, err := sqldb.Exec(ctx, "UPDATE user_organization SET content = $1 WHERE (organization_pub_key=$2 and user_pub_key=$3);",
+			userInformation,
+			organizationPubKey,
+			userPubKey)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return &UserPosted{Successful: "update"}, nil
+	} else {
+		_, err := sqldb.Exec(ctx, "INSERT INTO user_organization (id, organization_pub_key, user_pub_key, content) VALUES ($1, $2, $3, $4);",
+			registerID,
+			organizationPubKey,
+			userPubKey,
+			userInformation)
+		if err != nil {
+			return nil, err
+		}
+		return &UserPosted{Successful: "post"}, nil
+	}
 }

--- a/organization/users_organizations_test.go
+++ b/organization/users_organizations_test.go
@@ -1,0 +1,106 @@
+package organization
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"encore.app/admin"
+	"encore.app/commons/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUsersFromOrganization(t *testing.T) {
+	testutils.EnsureExclusiveDatabaseAccess(t)
+	fakeOrgName := "testing"
+
+	require.NoError(t, admin.InsertTestData(context.Background()))
+	testutils.ClearAllDBs()
+
+	users, err := GetUsersFromOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &GetUsersFromOrganizationParams{OrganizationId: "1"})
+	require.NoError(t, err)
+
+	require.Equal(t, len(users.Users), 0)
+
+	signingPubKey, _ := testutils.GenerateKeys()
+	encryptionPubKey, _ := testutils.GenerateKeys()
+
+	_, err = CreateOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &CreateOrgParams{
+		ID:               "000",
+		Name:             fakeOrgName,
+		SigningPubKey:    signingPubKey,
+		EncryptionPubKey: encryptionPubKey,
+	})
+	require.NoError(t, err)
+
+	users, err = GetUsersFromOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &GetUsersFromOrganizationParams{OrganizationId: "000"})
+	require.NoError(t, err)
+
+	require.Equal(t, len(users.Users), 0)
+
+	createUser, err := PostUserToOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &PostUserToOrganizationParams{OrganizationPubKey: "000", UserPubKey: "user", UserInformation: "content"})
+	require.NoError(t, err)
+	require.Equal(t, createUser.Successful, "post")
+
+	newUser, err := GetUsersFromOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &GetUsersFromOrganizationParams{OrganizationId: "000"})
+	require.NoError(t, err)
+
+	require.Equal(t, newUser.OrganizationId, "000")
+	require.Equal(t, len(newUser.Users), 1)
+	require.Equal(t, newUser.Users[0].UserId, "user")
+	require.Equal(t, newUser.Users[0].Content, "content")
+}
+
+func TestPostUserToOrganization(t *testing.T) {
+	testutils.EnsureExclusiveDatabaseAccess(t)
+	numberOfOrgs := 2
+	orgName := "name"
+
+	require.NoError(t, admin.InsertTestData(context.Background()))
+	testutils.ClearAllDBs()
+
+	for i := 0; i < numberOfOrgs; i++ {
+		signingPubKey, _ := testutils.GenerateKeys()
+		encryptionPubKey, _ := testutils.GenerateKeys()
+
+		_, err := CreateOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &CreateOrgParams{
+			ID:               strconv.Itoa(i),
+			Name:             orgName,
+			SigningPubKey:    signingPubKey,
+			EncryptionPubKey: encryptionPubKey,
+		})
+		require.NoError(t, err)
+	}
+
+	allOrgs, err := GetAllOrganizations(testutils.GetAuthenticatedContext(testutils.AdminPubKey))
+	require.NoError(t, err)
+	require.Equal(t, numberOfOrgs, len(allOrgs.Organizations))
+
+	for i, org := range allOrgs.Organizations {
+		require.Equal(t, strconv.Itoa(i), org.ID)
+		require.Equal(t, orgName, org.Name)
+		require.NotEqual(t, "", org.SigningPubKey)
+	}
+	users, err := GetUsersFromOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &GetUsersFromOrganizationParams{OrganizationId: "1"})
+	require.NoError(t, err)
+
+	require.Equal(t, len(users.Users), 0)
+
+	newUser, err := PostUserToOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &PostUserToOrganizationParams{OrganizationPubKey: "1", UserPubKey: "a", UserInformation: "content"})
+	require.NoError(t, err)
+
+	require.Equal(t, newUser.Successful, "post")
+
+	getUser, err := GetUsersFromOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &GetUsersFromOrganizationParams{OrganizationId: "1"})
+	require.NoError(t, err)
+	require.Equal(t, len(getUser.Users), 1)
+
+	updateUser, err := PostUserToOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &PostUserToOrganizationParams{OrganizationPubKey: "1", UserPubKey: "a", UserInformation: "updated content"})
+	require.NoError(t, err)
+
+	require.Equal(t, updateUser.Successful, "update")
+
+	getUser, err = GetUsersFromOrganization(testutils.GetAuthenticatedContext(testutils.AdminPubKey), &GetUsersFromOrganizationParams{OrganizationId: "1"})
+	require.NoError(t, err)
+	require.Equal(t, len(getUser.Users), 1)
+}


### PR DESCRIPTION
Added tests and instead of posting again the data of the user, now `PostUserToOrganization` updates the information of the user.